### PR TITLE
type based optional boxing/unboxing specialization

### DIFF
--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -39,7 +39,8 @@ type tag_info =
   | Blk_extension
   | Blk_na
   | Blk_some
-
+  | Blk_some_special
+    
 let default_tag_info : tag_info = Blk_na
 
 type field_dbg_info = 

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -41,6 +41,7 @@ type tag_info =
   | Blk_extension
   | Blk_na
   | Blk_some
+  | Blk_some_special (* ['a option] where ['a] can not inhabit a non-like value *)
     
 val default_tag_info : tag_info
 

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1360,18 +1360,50 @@ let val_of_option_bs_primitive : Lambda.primitive =
       prim_native_name = "";
       prim_native_float = false
     }
-    
+
+let val_of_unbox_option_bs_primitive : Lambda.primitive =
+  Pccall
+    {
+      prim_name = "#val_unbox_from_option";
+      prim_arity = 1;
+      prim_alloc = false;
+      prim_native_name = "";
+      prim_native_float = false
+    }  
 
 let make_constr_matching p def ctx = function
     [] -> fatal_error "Matching.make_constr_matching"
   | ((arg, mut) :: argl) ->
       let cstr = pat_as_constr p in
+      (* (if Datarepr.constructor_has_optional_shape cstr then *)
+      (*    match p.pat_desc with *)
+      (*    | Tpat_construct(_, _, *)
+      (*                     [ {  pat_type} ]) *)
+      (*      -> *)
+      (*        if Datarepr.cannot_inhabit_none_like_value pat_type then  *)
+      (*          Format.fprintf *)
+      (*            Format.err_formatter "@[special unboxing: %a @]@." *)
+      (*            Printtyp.raw_type_expr pat_type *)
+      (*    | _ -> () *)
+      (* ); *)
       let newargs =
         match cstr.cstr_tag with
-        | Cstr_block _ when !Clflags.bs_only && Datarepr.constructor_has_optional_shape cstr
+        | Cstr_block _ when
+            !Clflags.bs_only &&
+            Datarepr.constructor_has_optional_shape cstr
           ->
-            (* Format.fprintf Format.err_formatter "@[optional@]@."; *)
-            (Lprim (val_of_option_bs_primitive, [arg], p.pat_loc), Alias) :: argl
+            begin
+              let from_option = 
+                match p.pat_desc with
+                | Tpat_construct(_, _,
+                                 [ {
+                                   pat_type 
+                                 } ])
+                  when Datarepr.cannot_inhabit_none_like_value pat_type
+                  -> val_of_unbox_option_bs_primitive
+                | _ -> val_of_option_bs_primitive in 
+              (Lprim (from_option, [arg], p.pat_loc), Alias) :: argl
+            end
         | Cstr_constant _
         | Cstr_block _ ->
             make_field_args p.pat_loc Alias arg 0 (cstr.cstr_arity - 1) argl

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -949,7 +949,15 @@ and transl_exp0 e =
       | Cstr_block n ->
           let tag_info =
             if Datarepr.constructor_has_optional_shape cstr then
-              Lambda.Blk_some
+              begin 
+                match args with
+                | [arg] when  Datarepr.cannot_inhabit_none_like_value arg.exp_type 
+                  ->
+                    (* Format.fprintf Format.err_formatter "@[special boxingl@]@."; *)
+                    Lambda.Blk_some_special
+                | _ ->
+                    Lambda.Blk_some
+              end
             else (Lambda.Blk_constructor (cstr.cstr_name, cstr.cstr_nonconsts)) in
           begin try
             Lconst(Const_block(n,tag_info, List.map extract_constant ll))

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -48,6 +48,29 @@ let constructor_has_optional_shape ({cstr_attributes = attrs} : constructor_desc
   List.exists (fun (x,_) -> x.txt = internal_optional) attrs
 
 
+(**  [Types.constructor_description]
+     records the type at the definition type so for ['a option]
+     it will always be [Tvar]
+*)
+let cannot_inhabit_none_like_value (typ : Types.type_expr) =
+  match (Btype.repr typ).desc with
+  |  Tconstr(p, _,_) ->
+      if Path.same p Predef.path_option then false
+      else Predef.type_is_builtin_path p
+  | Ttuple _
+  | Tvariant _
+  | Tpackage _ 
+  | Tarrow _ -> true
+  | Tfield _ 
+  | Tpoly _ 
+  | Tunivar _ 
+  | Tlink _ 
+  | Tsubst _
+  | Tnil 
+  | Tvar _
+  | Tobject _ 
+    -> false
+    
 let constructor_descrs ty_res cstrs priv =
   let num_consts = ref 0 and num_nonconsts = ref 0  and num_normal = ref 0 in
   List.iter

--- a/typing/datarepr.mli
+++ b/typing/datarepr.mli
@@ -18,7 +18,11 @@ open Types
 
 val constructor_has_optional_shape:
   Types.constructor_description -> bool
-  
+
+
+val cannot_inhabit_none_like_value:
+  Types.type_expr -> bool
+
 val constructor_descrs:
   type_expr -> constructor_declaration list ->
   private_flag -> (Ident.t * constructor_description) list

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -26,6 +26,7 @@ let wrap create s =
 let ident_create = wrap Ident.create
 let ident_create_predef_exn = wrap Ident.create_predef_exn
 
+
 let ident_int = ident_create "int"
 and ident_char = ident_create "char"
 and ident_string = ident_create "string"
@@ -41,6 +42,12 @@ and ident_int32 = ident_create "int32"
 and ident_int64 = ident_create "int64"
 and ident_lazy_t = ident_create "lazy_t"
 and ident_bytes = ident_create "bytes"
+
+
+let type_is_builtin_path p =
+  match p with
+  | Pident {stamp} -> stamp >= ident_int.stamp && stamp  <= ident_bytes.stamp
+  | _ -> false
 
 let path_int = Pident ident_int
 and path_char = Pident ident_char

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -63,3 +63,6 @@ val build_initial_env:
 
 val builtin_values: (string * Ident.t) list
 val builtin_idents: (string * Ident.t) list
+
+
+val type_is_builtin_path : Path.t -> bool


### PR DESCRIPTION
Use type information to decide when boxing of optionals is not required, so give a fast path in that case.
For example `option(int)` never needs boxing.