### PR TITLE
Expose bs_gentype in 4.06

### DIFF
--- a/typing/cmt_format.ml
+++ b/typing/cmt_format.ml
@@ -192,11 +192,11 @@ let save_cmt filename modname binary_annots sourcefile initial_env cmi =
            cmt_use_summaries = need_to_clear_env;
          } in
          output_cmt oc cmt)
-#if undefined BS_NO_COMPILER_PATCH then  
+#if undefined BS_NO_COMPILER_PATCH then
     (* TODO: does not make sense to do post-proccesing for [Partial_implementaiton]*)
-  ; match Sys.getenv "BS_CMT_POST_PROCESS_CMD" with
-    | exception _ -> ()
-    | cmd -> ignore (Sys.command (cmd ^ " -cmt-add " ^ filename ^ (match sourcefile with None -> "" | Some sourcefile -> ":" ^ sourcefile)))
+  ; match !Clflags.bs_gentype with
+    | None -> ()
+    | Some cmd -> ignore (Sys.command (cmd ^ " -cmt-add " ^ filename ^ (match sourcefile with None -> "" | Some sourcefile -> ":" ^ sourcefile)))
 #end
   end;
   clear ()

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -404,17 +404,18 @@ let parse_arguments f msg =
   | Arg.Bad msg -> Printf.eprintf "%s" msg; exit 2
   | Arg.Help msg -> Printf.printf "%s" msg; exit 0
 
-#if undefined  BS_NO_COMPILER_PATCH then 
+#if undefined  BS_NO_COMPILER_PATCH then
 type mli_status = Mli_na | Mli_exists | Mli_non_exists
 let no_implicit_current_dir = ref false
 let assume_no_mli = ref Mli_na
 let record_event_when_debug = ref true (* turned off in BuckleScript*)
-let bs_vscode = 
+let bs_vscode =
     try ignore @@ Sys.getenv "BS_VSCODE" ; true with _ -> false
-    (* We get it from environment variable mostly due to 
+    (* We get it from environment variable mostly due to
        we don't want to rebuild when flip on or off
     *)
 let dont_record_crc_unit : string option ref = ref None
 let bs_only = ref false
+let bs_gentype = ref None
 let no_assert_false = ref false
 #end

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -232,13 +232,14 @@ val print_arguments : string -> unit
 (* [reset_arguments ()] clear all declared arguments *)
 val reset_arguments : unit -> unit
 
-#if undefined  BS_NO_COMPILER_PATCH then 
+#if undefined  BS_NO_COMPILER_PATCH then
 type mli_status = Mli_na | Mli_exists | Mli_non_exists
 val no_implicit_current_dir : bool ref
-val assume_no_mli : mli_status ref 
-val record_event_when_debug : bool ref 
+val assume_no_mli : mli_status ref
+val record_event_when_debug : bool ref
 val bs_vscode : bool
 val dont_record_crc_unit : string option ref
 val bs_only : bool ref (* set true on bs top*)
+val bs_gentype : string option ref
 val no_assert_false : bool ref
 #end


### PR DESCRIPTION
This corresponds to https://github.com/BuckleScript/bucklescript/commit/755c42d3164d7d767ac2e21dc364e4d0b49b1bf8
but for 4.06