### PR TITLE
[Super errors] Expose previously shadowed `report_error` from typemod.ml

### DIFF
--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2037,6 +2037,10 @@ let report_error ppf = function
         "This is an alias for module %a, which is missing"
         path p
 
+#if true then
+let super_report_error_no_wrap_printing_env = report_error
+#end
+
 let report_error env ppf err =
   Printtyp.wrap_printing_env env (fun () -> report_error ppf err)
 

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -87,6 +87,10 @@ type error =
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
+#if true then
+val super_report_error_no_wrap_printing_env: formatter -> error -> unit
+#end
+
 val report_error: Env.t -> formatter -> error -> unit
 
 


### PR DESCRIPTION
Used by super_typemod.ml in BuckleScript